### PR TITLE
Removed unneccesary requirements, and made requirement installation use requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,19 +8,11 @@ You will need to install [Python 3](https://www.python.org/downloads/) or [Anaco
 
 ## Requirements
 
-You will need to install the following:
+You can install the requirements by running:
 ```
-$ pip install discord.py
+$ pip install -r requirements.txt
 ```
-```
-$ pip install aiohttp
-```
-```
-$ pip install websockets
-```
-```
-$ pip install requests
-```
+
 
 ## Commands
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+discord.py
+requests


### PR DESCRIPTION
Removed websockets and aiohttp from the requirements installation (it is automatically installed when you install discord.py) and replaced the four pip install statements in the readme with one statement using the requirements.txt file.