### PR TITLE
Locked down eval call in calc command to prevent execution of user-provided code.

### DIFF
--- a/viking.py
+++ b/viking.py
@@ -99,7 +99,7 @@ async def calc(*args):
         original = ''.join(args)
         args = [x.replace('^', '**') for x in args]
         problem = ''.join(args)
-        answer = eval(problem)
+        answer = eval(problem, {"__builtins__": None}, {})
     except:
         await Viking.say("I don't understand that non-sense")
         return


### PR DESCRIPTION
Removed access to functions such as __import__, open, etc. in the calc command to prevent the running of arbitrary user-provided code. Resolves #4