### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/cogs/audio.py
+++ b/cogs/audio.py
@@ -4,7 +4,7 @@ import os
 import sys
 from async_timeout import timeout
 from discord.ext import commands
-from fuzzywuzzy import process
+from rapidfuzz import process
 from random import choice
 from utilities.format import format_list
 
@@ -75,11 +75,10 @@ class Audio(commands.Cog):
             if query == filename:
                 return sound
 
-        match = process.extractOne(query, sounds)
-        filename, score = match
+        match = process.extractOne(query, sounds, score_cutoff=75)
 
-        if score > 75:
-            return filename
+        if match:
+            return match[0]
 
         return None
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,10 @@ aiodns
 asyncpg
 cchardet
 discord.py[voice]
-fuzzywuzzy[speedup]
 paramiko
 pipdeptree
 pip-upgrader
 python-dateutil
-python-Levenshtein
+rapidfuzz
 tabulate
 uvloop; sys_platform == 'linux'

--- a/utilities/lol.py
+++ b/utilities/lol.py
@@ -1,5 +1,5 @@
 from database.model import LoLChampions, LoLSpells
-from fuzzywuzzy import process
+from rapidfuzz import process
 from utilities.format import format_list
 from utilities.request import fetch
 

--- a/utilities/nhl.py
+++ b/utilities/nhl.py
@@ -2,7 +2,7 @@ import discord
 from asyncio import TimeoutError
 from database.model import NHLTeams, NHLPlayers
 from datetime import datetime
-from fuzzywuzzy import process
+from rapidfuzz import process
 from utilities.format import format_list
 from utilities.request import fetch
 


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy